### PR TITLE
remove the * rule in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,3 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-
-* @qixotic @dctaf @poornimaramesh @Jayprakash-SE @sidravi1 @eliagandolfi


### PR DESCRIPTION
for the same reason in https://github.com/agency-fund/evidential-be/pull/10#discussion_r2211775471; just rely on our branch ruleset on `docs` that requires 1 approval from those with write privs.