### PR TITLE
add notes on request encapsulation

### DIFF
--- a/docs/integration/integration.md
+++ b/docs/integration/integration.md
@@ -104,3 +104,37 @@ sequenceDiagram
         traffic to route into the experiment, and then make the Evidential request for each (vs e.g.
         routing 100% of your users into an Evidential experiment in which 90% are in a Control arm and
         10% in Treatment).
+
+## Additional developer notes
+
+### Request Encapsulation Middleware
+Evidential's API server includes middleware that allows clients to encapsulate their request payloads inside a wrapper object. This is useful when the client application has a fixed request format that cannot be changed to match Evidential's expected schema.
+
+For example, if the client application sends requests in the following format:
+
+```json
+{
+  "data": {
+    "payload": {
+      "participant_id": "12345",
+      "other_field": "value"
+    }
+  }
+}
+```
+
+But the expected format by Evidential's API is:
+
+```json
+{
+  "participant_id": "12345",
+  "other_field": "value"
+}
+```
+The client can configure the middleware to extract the actual payload using a JSON Pointer path as follows:
+
+```
+path/to/endpoint?_unwrap=/data/payload
+```
+This will instruct the middleware to unwrap the request body and forward only the inner payload to the API endpoint.
+

--- a/docs/integration/integration.md
+++ b/docs/integration/integration.md
@@ -108,7 +108,8 @@ sequenceDiagram
 ## Additional developer notes
 
 ### Request Encapsulation Middleware
-Evidential's API server includes middleware that allows clients to encapsulate their request payloads inside a wrapper object. This is useful when the client application has a fixed request format that cannot be changed to match Evidential's expected schema.
+
+Evidential's API server includes middleware that allows clients to encapsulate their request payloads inside a wrapper object. This is useful when the client application you are using to send requests to Evidential has a fixed request format that cannot be changed to match Evidential's expected schema.
 
 For example, if the client application sends requests in the following format:
 
@@ -131,10 +132,11 @@ But the expected format by Evidential's API is:
   "other_field": "value"
 }
 ```
+
 The client can configure the middleware to extract the actual payload using a JSON Pointer path as follows:
 
 ```
 path/to/endpoint?_unwrap=/data/payload
 ```
-This will instruct the middleware to unwrap the request body and forward only the inner payload to the API endpoint.
 
+This will instruct the middleware to unwrap the request body and forward only the inner payload to the API endpoint.


### PR DESCRIPTION
Added notes on request encapsulation to unwrap payloads with fixed client-side payload structures.

Fixes [issue 231](https://github.com/agency-fund/evidential-sprint/issues/231)